### PR TITLE
Feat/Modal para cadastro de novo estágio

### DIFF
--- a/assets/css/pagina_aluno.css
+++ b/assets/css/pagina_aluno.css
@@ -317,6 +317,181 @@ body {
   transform: scale(0.95);
 }
 
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(16, 24, 40, 0.55);
+  backdrop-filter: blur(4px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal-overlay.ativo {
+  display: flex;
+}
+
+.modal-conteudo {
+  width: min(720px, 100%);
+  background: #f9fafb;
+  border-radius: 28px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  padding: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.modal-cabecalho {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.modal-cabecalho h2 {
+  font-size: 1.35rem;
+  margin-bottom: 0.25rem;
+}
+
+.modal-cabecalho p {
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.fechar-modal {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 999px;
+  background: #e5e7eb;
+  color: #1f2937;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.fechar-modal:hover {
+  background: #d1d5db;
+}
+
+.modal-formulario {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.modal-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.modal-grid input {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: white;
+  padding: 0.95rem 1rem;
+  color: #111827;
+  font-size: 0.95rem;
+}
+
+.modal-grid input[type="file"] {
+  padding: 0.7rem 0.9rem;
+}
+
+.span-dobrado {
+  grid-column: 1 / -1;
+}
+
+.modal-acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.botao-cancelar,
+.botao-cadastrar {
+  border: none;
+  border-radius: 12px;
+  padding: 0.95rem 1.35rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.botao-cancelar {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.botao-cancelar:hover {
+  background: #e5e7eb;
+}
+
+.botao-cadastrar {
+  background: #1d4ed8;
+  color: white;
+}
+
+.botao-cadastrar:hover {
+  background: #1e40af;
+}
+
+.mensagem {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 92%;
+  min-width: 280px;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
+  font-weight: 700;
+  text-align: center;
+  z-index: 1100;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+.sucesso {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.erro {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.oculto {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+@media (max-width: 900px) {
+  .modal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-conteudo {
+    padding: 1.25rem;
+  }
+}
+
 /* Responsividade: Desktop */
 @media (min-width: 1024px) {
   .mobile {

--- a/assets/js/pagina_aluno.js
+++ b/assets/js/pagina_aluno.js
@@ -1,0 +1,1 @@
+const URL_ESTAGIO = import.meta.env.VITE_URL_JSON_ESTAGIO;

--- a/assets/js/pagina_aluno.js
+++ b/assets/js/pagina_aluno.js
@@ -1,1 +1,154 @@
 const URL_ESTAGIO = import.meta.env.VITE_URL_JSON_ESTAGIO;
+
+const mostrarMensagem = (texto, tipo = "erro") => {
+  const mensagem = document.getElementById("mensagem-estagio");
+  if (!mensagem) return;
+  mensagem.textContent = texto;
+  mensagem.classList.remove("oculto", "sucesso", "erro");
+  mensagem.classList.add(tipo === "sucesso" ? "sucesso" : "erro");
+
+  if (mensagem.dataset.timeoutId) {
+    window.clearTimeout(mensagem.dataset.timeoutId);
+  }
+
+  const timeoutId = window.setTimeout(() => {
+    mensagem.classList.add("oculto");
+  }, 5000);
+
+  mensagem.dataset.timeoutId = timeoutId;
+};
+
+const lerArquivoComoBase64 = (arquivo) => {
+  return new Promise((resolve, reject) => {
+    if (!arquivo) {
+      resolve(null);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("Falha ao ler o arquivo"));
+    reader.readAsDataURL(arquivo);
+  });
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  const abrirModal = document.getElementById("abrir-modal-estagio");
+  const overlay = document.getElementById("modal-overlay");
+  const fecharModal = document.getElementById("fechar-modal-estagio");
+  const botaoCancelar = document.querySelector(".botao-cancelar");
+  const formulario = document.getElementById("formulario-estagio");
+
+  const abrir = () => {
+    overlay.classList.add("ativo");
+    document.body.style.overflow = "hidden";
+  };
+
+  const fechar = () => {
+    overlay.classList.remove("ativo");
+    document.body.style.overflow = "";
+  };
+
+  if (abrirModal) {
+    abrirModal.addEventListener("click", abrir);
+  }
+
+  if (fecharModal) {
+    fecharModal.addEventListener("click", fechar);
+  }
+
+  if (botaoCancelar) {
+    botaoCancelar.addEventListener("click", fechar);
+  }
+
+  if (overlay) {
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay) {
+        fechar();
+      }
+    });
+  }
+
+  if (formulario) {
+    formulario.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      const empresa = formulario.querySelector("[name=empresa]").value.trim();
+      const dataInicio = formulario.querySelector("[name=dataInicio]").value;
+      const nomeOrientador = formulario.querySelector("[name=nomeOrientador]").value.trim();
+      const cursoEstagiario = formulario.querySelector("[name=cursoEstagiario]").value.trim();
+      const emailCoordenador = formulario.querySelector("[name=emailCoordenador]").value.trim();
+      const termoCompromisso = formulario.querySelector("[name=termoCompromisso]").files[0];
+      const termoOrientacao = formulario.querySelector("[name=termoOrientacao]").files[0];
+      const botaoEnviar = formulario.querySelector("button[type=submit]");
+
+      if (
+        !empresa ||
+        !dataInicio ||
+        !nomeOrientador ||
+        !cursoEstagiario ||
+        !emailCoordenador ||
+        !termoCompromisso ||
+        !termoOrientacao
+      ) {
+        mostrarMensagem("Preencha todos os campos obrigatórios.", "erro");
+        return;
+      }
+
+      botaoEnviar.disabled = true;
+      const textoOriginal = botaoEnviar.innerText;
+      botaoEnviar.innerText = "Enviando...";
+
+      try {
+        const [compBase64, oriBase64] = await Promise.all([
+          lerArquivoComoBase64(termoCompromisso),
+          lerArquivoComoBase64(termoOrientacao),
+        ]);
+
+        const payload = {
+          empresa,
+          dataInicio,
+          nomeOrientador,
+          cursoEstagiario,
+          emailCoordenador,
+          termoCompromisso: {
+            fileName: termoCompromisso.name,
+            fileType: termoCompromisso.type,
+            fileSize: termoCompromisso.size,
+            path: `files/termo-compromisso/${termoCompromisso.name}`,
+            content: compBase64,
+          },
+          termoOrientacao: {
+            fileName: termoOrientacao.name,
+            fileType: termoOrientacao.type,
+            fileSize: termoOrientacao.size,
+            path: `files/termo-orientacao/${termoOrientacao.name}`,
+            content: oriBase64,
+          },
+        };
+
+        const resposta = await fetch(URL_ESTAGIO, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (resposta.ok) {
+          mostrarMensagem("Estágio cadastrado com sucesso!", "sucesso");
+          formulario.reset();
+          fechar();
+        } else {
+          mostrarMensagem("Não foi possível cadastrar o estágio.", "erro");
+        }
+      } catch (erro) {
+        console.error("Erro ao enviar cadastro de estágio:", erro);
+        mostrarMensagem("Erro ao enviar o cadastro do estágio.", "erro");
+      } finally {
+        botaoEnviar.disabled = false;
+        botaoEnviar.innerText = textoOriginal;
+      }
+    });
+  }
+});

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,5 +1,5 @@
 import bcrypt from "bcryptjs";
-const URL_CADASTRO = import.meta.env.VITE_URL_JSON;
+const URL_USUARIO = import.meta.env.VITE_URL_JSON_USUARIO;
 
 function Troca_Telas() {
   // ==========================================
@@ -312,7 +312,7 @@ function Cadastro() {
     Gerar_Hash(usuario);
 
     try {
-      const busca = await fetch(URL_CADASTRO);
+      const busca = await fetch(URL_USUARIO);
       const lista_usuarios = await busca.json();
 
       const email_existe = lista_usuarios.some(
@@ -333,7 +333,7 @@ function Cadastro() {
         return;
       }
       // Envia para o JSON da API
-      const resposta = await fetch(URL_CADASTRO, {
+      const resposta = await fetch(URL_USUARIO, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -370,7 +370,7 @@ async function login(event) {
   let password_value = password.value;
 
   // Busca o arquivo JSON e converte para um objeto JavaScript
-  const resposta = await fetch(URL_CADASTRO);
+  const resposta = await fetch(URL_USUARIO);
   const users = await resposta.json();
 
   // Procura o usuário com o email fornecido

--- a/pages/pagina_aluno.html
+++ b/pages/pagina_aluno.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<div id="mensagem-estagio" class="mensagem oculto"></div>
+
 <div id='titulo'>
     <h1>Bem Vindo Ao Portal de Defesas de Estágio</h1>
     <p>Gerencie seus estágios e encontre novas oportunidades</p>
@@ -20,7 +22,7 @@
     <h4 class="mobile">Registre seu novo estágio.</h4>
     <div class="container-novo-estagio-desktop">
         <h4 class="desktop">Registre um novo estágio para começar o processo de aprovação.</h4>
-        <button type="button"><i class="fa-solid fa-plus"></i><p>Novo Estágio</p></button>
+        <button id="abrir-modal-estagio" type="button"><i class="fa-solid fa-plus"></i><p>Novo Estágio</p></button>
     </div>
 </div>
 
@@ -117,6 +119,60 @@
 
     </div>
 </section>
+
+<div id="modal-overlay" class="modal-overlay">
+  <div class="modal-conteudo">
+    <div class="modal-cabecalho">
+      <div>
+        <h2>Cadastrar Novo Estágio</h2>
+        <p>Preencha os dados do Estágio</p>
+      </div>
+      <button id="fechar-modal-estagio" type="button" class="fechar-modal" aria-label="Fechar modal">
+        <i class="fa-solid fa-xmark"></i>
+      </button>
+    </div>
+
+    <form class="modal-formulario" id="formulario-estagio" autocomplete="off">
+      <div class="modal-grid">
+        <label>
+          Empresa
+          <input type="text" name="empresa" placeholder="Nome da empresa">
+        </label>
+        <label>
+          Data de Início
+          <input type="date" name="dataInicio">
+        </label>
+        <label>
+          Nome do Orientador
+          <input type="text" name="nomeOrientador" placeholder="Nome do orientador">
+        </label>
+        <label>
+          Curso do Estagiário
+          <input type="text" name="cursoEstagiario" placeholder="Engenharia de Software">
+        </label>
+        <label>
+          Email do Coordenador de Curso
+          <input type="email" name="emailCoordenador" placeholder="coordenador@ifpb.edu.br">
+        </label>
+        <label class="span-dobrado">
+          Upload do Termo de Compromisso
+          <input type="file" name="termoCompromisso">
+        </label>
+        <label class="span-dobrado">
+          Upload do Termo de Orientação
+          <input type="file" name="termoOrientacao">
+        </label>
+      </div>
+
+      <div class="modal-acoes">
+        <button type="button" class="botao-cancelar">Cancelar</button>
+        <button type="submit" class="botao-cadastrar">Cadastrar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script type="module" src="../assets/js/pagina_aluno.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
Adicionado o modal de cadastro de estágio na página do aluno com a estilização do modal.

Se o usuário deixar de enviar um campo, é emitida uma mensagem de erro temporária baseada nas mensagens de erro de login e cadastro.

Também foi implementada a lógica JavaScript para validar os campos obrigatórios e a lógica necessária para enviar os dados do estágio cadastrado em formato JSON a um endpoint.


https://github.com/user-attachments/assets/d1f00765-03f5-4d59-9b38-2c124f929808

