### PR TITLE
fix: corrige caminho da logo para usar BASE_URL

### DIFF
--- a/components/cabecalho.js
+++ b/components/cabecalho.js
@@ -7,12 +7,12 @@ export function injetarCabecalho() {
         console.error('Div #conteiner-cabecalho não encontrada na página.');
         return;
     }
-
+    const base = import.meta.env.BASE_URL;
     // O HTML do nosso cabeçalho
     conteiner.innerHTML = `
         <header class="cabecalho-principal">
             <div class="cabecalho-logo">
-                <img src="../assets/img/preview-pde-transparente.png" alt="Logo PDE">
+                <img src="${base}assets/img/preview-pde-transparente.png" alt="Logo PDE">
             </div>
             
             <button class="botao-menu-mobile" id="botao-menu" aria-label="Abrir menu">


### PR DESCRIPTION
o PR anterior ainda estava com o caminho relativo. Ajustei para usar a BASE_URL que Ryan configurou no vite.config.js.