### PR TITLE
Fix/deploy logo

### DIFF
--- a/components/cabecalho.js
+++ b/components/cabecalho.js
@@ -9,9 +9,7 @@ export function injetarCabecalho() {
         console.error('Div #conteiner-cabecalho não encontrada na página.');
         return;
     }
-
-    const base = import.meta.env.BASE_URL;
-
+    
     // O HTML do nosso cabeçalho
     conteiner.innerHTML = `
         <header class="cabecalho-principal">

--- a/components/cabecalho.js
+++ b/components/cabecalho.js
@@ -8,11 +8,13 @@ export function injetarCabecalho() {
         return;
     }
 
+    const base = import.meta.env.BASE_URL;
+
     // O HTML do nosso cabeçalho
     conteiner.innerHTML = `
         <header class="cabecalho-principal">
             <div class="cabecalho-logo">
-                <img src="../assets/img/preview-pde-transparente.png" alt="Logo PDE">
+                <img src="${base}assets/img/preview-pde-transparente.png" alt="Logo PDE">
             </div>
             
             <button class="botao-menu-mobile" id="botao-menu" aria-label="Abrir menu">

--- a/components/cabecalho.js
+++ b/components/cabecalho.js
@@ -1,3 +1,5 @@
+import logoUrl from '../assets/img/preview-pde-transparente.png';
+
 // components/cabecalho.js
 
 export function injetarCabecalho() {
@@ -14,7 +16,7 @@ export function injetarCabecalho() {
     conteiner.innerHTML = `
         <header class="cabecalho-principal">
             <div class="cabecalho-logo">
-                <img src="${base}assets/img/preview-pde-transparente.png" alt="Logo PDE">
+                <img src="${logoUrl}" alt="Logo PDE">
             </div>
             
             <button class="botao-menu-mobile" id="botao-menu" aria-label="Abrir menu">


### PR DESCRIPTION
Este PR corrige o caminho da logo no cabeçalho. Anteriormente, o uso de caminhos relativos estava causando erro após o build do Vite . 

visualização no npm run preview:
<img width="146" height="85" alt="image" src="https://github.com/user-attachments/assets/0d8c2917-2662-4adf-b5aa-d8d238ada5c8" />
