### PR TITLE
feat: adiciona header responsivo para tablet e desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@
 
 # production
 /build
-
+/dist
 # misc
 .DS_Store
 *.pem

--- a/src/app/dashboard/alunos/page.tsx
+++ b/src/app/dashboard/alunos/page.tsx
@@ -1,5 +1,6 @@
 import Aside from "@/components/Aside";
 import NavMobile from "@/components/NavMobile";
+import Header from "@/components/Header";
 
 export default function Dashboard() {
     return (

--- a/src/app/dashboard/bancas/page.tsx
+++ b/src/app/dashboard/bancas/page.tsx
@@ -1,5 +1,6 @@
 import Aside from "@/components/Aside";
 import NavMobile from "@/components/NavMobile";
+import Header from "@/components/Header";
 
 export default function Dashboard() {
     return (

--- a/src/app/dashboard/calendario/page.tsx
+++ b/src/app/dashboard/calendario/page.tsx
@@ -1,5 +1,6 @@
 import Aside from "@/components/Aside";
 import NavMobile from "@/components/NavMobile";
+import Header from "@/components/Header";
 
 export default function Dashboard() {
     return (

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Aside from "@/components/Aside";
 import NavMobile from "@/components/NavMobile";
+import Header from "@/components/Header";
 
 
 const geistSans = Geist({
@@ -26,14 +27,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-5">
+    <div className="grid grid-cols-1 md:grid-cols-[220px_1fr] min-h-screen">
 
     {/* Todo o conteúdo compartilhado fixo entre as telas da dashboard devem ficar aqui*/}
     <Aside perfil="orientador" />
     <NavMobile perfil="aluno" />
 
-    <main className="col-span-1 lg:col-span-4">{children}</main>
-
+    <div>
+      <Header nome="Dr. Ricardo Silva" perfil="orientador"/>
+      <main>{children}</main>
+    </div>
     </div>
   );
 }

--- a/src/app/dashboard/perfil/page.tsx
+++ b/src/app/dashboard/perfil/page.tsx
@@ -1,5 +1,6 @@
 import Aside from "@/components/Aside";
 import NavMobile from "@/components/NavMobile";
+import Header from "@/components/Header";
 
 export default function Dashboard() {
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Aside from "@/components/Aside";
 import NavMobile from "@/components/NavMobile";
+import Header from "@/components/Header";
 
 export default function Home() {
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import NotificationsOutlineIcon from '@iconify-react/material-symbols/notifications-outline';
+import DarkModeOutlineIcon from '@iconify-react/material-symbols/dark-mode-outline';
+
+type HeaderProps = Readonly<{
+    nome: string;
+    perfil: 'aluno' | 'orientador' | 'coordenador';
+}>;
+
+export default function Header(props: HeaderProps) {
+    return (
+        <header className='hidden md:flex items-center justify-end gap-4 h-16 px-6 bg-white w-full'>
+            <button className='p-2 rounded-md hover:bg-gray-100 transition-colors cursor-pointer' aria-label='Notificações'>
+                <NotificationsOutlineIcon className='w-5 h-5 text-gray-600 hover:text-blue-700' />
+            </button>
+
+            <button className='p-2 rounded-md hover:bg-gray-100 transition-colors cursor-pointer' aria-label='Alternar tema'>
+                <DarkModeOutlineIcon className='w-5 h-5 text-gray-600 hover:text-blue-700' />
+            </button>
+
+            <div className='text-right border-l border-gray-300 pl-4'>
+              <p className='font-semibold text-sm whitespace-nowrap'> {props.nome}</p>
+              <p className='text-xs text-gray-500'>
+                {props.perfil === 'aluno' ? 'Aluno' : props.perfil === 'orientador' ? 'Orientador' : 'Coordenador'}
+              </p>
+            </div>
+
+            <div className='w-10 h-10 rounded-full bg-gray-300 flex-shrin-0'>
+            
+            </div>
+        </header>
+    );
+}


### PR DESCRIPTION
Nesse PR, foi feito:

- Criação do componente Header compartilhado da dashboard.

- Ajustes de responsividade para tablet e desktop.




https://github.com/user-attachments/assets/bb330c32-b0bc-4ad0-9d63-07ba190fc124





