### PR TITLE
style: links nav e aside dark

### DIFF
--- a/src/components/Aside.tsx
+++ b/src/components/Aside.tsx
@@ -22,7 +22,7 @@ function NavLinkItem({
   return (
     <Link
       href={href}
-      className={`flex items-center gap-2 p-2 rounded-md ${isActive ? "bg-gray-200 text-blue-700 dark:bg-slate-700 dark:text-blue-600" : "text-gray-700 hover:bg-gray-200 hover:text-blue-700 dark:text-blue-600/50 dark:hover:bg-slate-700 dark:hover:text-blue-600"}`}
+      className={`flex items-center gap-2 p-2 rounded-md ${isActive ? "bg-gray-200 text-blue-600 dark:bg-slate-800/50 dark:border-l-4 dark:border-blue-500 dark:text-blue-400" : "text-gray-700 hover:bg-gray-200 hover:text-blue-600 dark:text-slate-400 dark:hover:bg-slate-800/50 dark:hover:text-blue-400"}`}
     >
       {icon}
       <h3>{label}</h3>

--- a/src/components/NavMobile.tsx
+++ b/src/components/NavMobile.tsx
@@ -22,7 +22,7 @@ function NavLinkItem({
   return (
     <Link
       href={href}
-      className={`flex flex-col items-center px-4 py-2 rounded-full transition-colors duration-300 ${isActive ? "bg-gray-200 text-blue-700 dark:bg-slate-800/50 dark:text-blue-600" : "dark:text-blue-600/50 dark:hover:bg-slate-800/50 dark:hover:text-blue-600"}`}
+      className={`flex flex-col items-center px-4 py-2 rounded-full transition-colors duration-300 ${isActive ? "bg-gray-200 text-blue-700 dark:bg-slate-800/50 dark:text-blue-600" : "dark:text-slate-400 dark:hover:bg-slate-800/50 dark:hover:text-blue-600"}`}
     >
       {icon}
       <h3 className={`text-[0.6rem] ${isActive ? "block" : "hidden"}`}>

--- a/src/components/NavMobile.tsx
+++ b/src/components/NavMobile.tsx
@@ -22,7 +22,7 @@ function NavLinkItem({
   return (
     <Link
       href={href}
-      className={`flex flex-col items-center px-4 py-2 rounded-full transition-colors duration-300 ${isActive ? "bg-gray-200 text-blue-700 dark:bg-slate-700 dark:text-blue-600" : "dark:text-blue-600/50 dark:hover:bg-slate-700 dark:hover:text-blue-600"}`}
+      className={`flex flex-col items-center px-4 py-2 rounded-full transition-colors duration-300 ${isActive ? "bg-gray-200 text-blue-700 dark:bg-slate-800/50 dark:text-blue-600" : "dark:text-blue-600/50 dark:hover:bg-slate-800/50 dark:hover:text-blue-600"}`}
     >
       {icon}
       <h3 className={`text-[0.6rem] ${isActive ? "block" : "hidden"}`}>


### PR DESCRIPTION
Nesse PR:

- Alterei as cores dos links do nav e aside para melhor o contraste no modo escuro

<img width="718" height="311" alt="image" src="https://github.com/user-attachments/assets/e2d6ff7b-6954-4d6b-b3fd-80ca836225c0" />
<img width="587" height="803" alt="image" src="https://github.com/user-attachments/assets/1461ede1-0026-46ab-8aac-b6497b103d17" />

